### PR TITLE
Let it serve JavaScript and CSS files

### DIFF
--- a/emberweb/emberweb.tcl
+++ b/emberweb/emberweb.tcl
@@ -41,6 +41,8 @@ namespace eval ::emberweb {
       png  image/png
       jpg  image/jpeg
       json application/json
+      js   text/javascript
+      css  text/css
    }
 }
 


### PR DESCRIPTION
I was playing with your server inside my own project and noticed that it would not serve JavaScript files due to absent MIME mapping. I thoughtm js and css were pretty common files so here's a patch :)
